### PR TITLE
Update ubuntu base image to latest LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use ubuntu eoan as parent image
-FROM ubuntu:eoan
+FROM ubuntu:latest
 # Set maintainer
 LABEL maintainer="Laurens Sion <laurens@sion.info>"
 


### PR DESCRIPTION
According to <https://hub.docker.com/_/ubuntu>, "The `ubuntu:latest` tag points to the "latest LTS", since that's the version recommended for general use."
Therefore, it is best to use the `latest` tag to stay up to date. Moreover, the texlive installation will also be reasonably up-to-date.